### PR TITLE
Fix build on Fedora, openSuse etc. - use sys/xattr.h instead of attr/xattr.h 

### DIFF
--- a/src/HfsFuseVolume.cpp
+++ b/src/HfsFuseVolume.cpp
@@ -12,7 +12,8 @@
 #elif defined(_MSC_VER)
 #  define ENOATTR (93) // TODO better ?
 #else
-#  include <attr/xattr.h> // for ENOATTR
+#  include <sys/xattr.h>
+#  define ENOATTR ENODATA
 #endif
 
 #include <iostream>


### PR DESCRIPTION
Following on #8

Applications should use sys/xattr.h instead of attr/xattr.h which is missing in many distros (Redhat, Fedora, openSuse, Centos) and existing source code will not compile.

Proposed change should work on all distros - tested on Debian, Fedora and openSuse